### PR TITLE
Add isssue template referring to discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question
+    url: https://github.com/notaryproject/nv2/discussions
+    about: Ask questions and discuss with other community members


### PR DESCRIPTION
This PR adds a reference to Github discussions when someone tries to create a new issue.

Didn't define templates yet so kept free format issues open for now.

Defining templates allows for automation using github actions. E.g. Agenda items to discuss in meetings etc.